### PR TITLE
Fix firestore.rules and storage.rules

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -1,7 +1,7 @@
 service cloud.firestore {
   match /databases/{database}/documents {
     match /{document=**} {
-      allow read, write;
+      allow read, write: if false;
     }
   }
 }

--- a/storage.rules
+++ b/storage.rules
@@ -1,7 +1,7 @@
 service firebase.storage {
   match /b/{bucket}/o {
     match /{allPaths=**} {
-      allow read, write: if request.auth!=null;
+      allow read, write: if false;
     }
   }
 }


### PR DESCRIPTION
The default security rules in firestore.rule seem to default to all permissions. Since we believe that if production operations are unaware of or follow this setting, accidents could occur, we suggest that the default setting be to not allow all permissions.

The default setting on Firebase is to deny all production environment modes, so we followed that.